### PR TITLE
feat:  added trace_id in json log

### DIFF
--- a/src/DataDogFormatter.php
+++ b/src/DataDogFormatter.php
@@ -47,6 +47,14 @@ class DataDogFormatter extends JsonFormatter
         $record['source']   = 'php-' . php_sapi_name();
         $record['service']  = config('app.name');
         $record['hostname'] = gethostname();
+        
+        if(extension_loaded('DDTrace')){
+            $context = \DDTrace\current_context();
+            $record['dd'] = [
+                'trace_id' => $context['trace_id'],
+                'span_id'  => $context['span_id'],
+            ];
+        }
 
         return parent::format($record);
     }


### PR DESCRIPTION
DataDog support connecting between PHP Logs and Traces. So We need to add trace_id in DataDog log.


https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/php/#automatic-injection