### PR TITLE
Fix: type error for Monolog v2

### DIFF
--- a/src/DataDogFormatter.php
+++ b/src/DataDogFormatter.php
@@ -29,7 +29,7 @@ class DataDogFormatter extends JsonFormatter
      * @see  \Monolog\Formatter\JsonFormatter::format()
      * @see  https://docs.datadoghq.com/logs/processing/#reserved-attributes
      */
-    public function format(array $record)
+    public function format(array $record): string
     {
         if (isset($record[self::LARAVEL_LOG_DATETIME_KEY]) &&
             ($record[self::LARAVEL_LOG_DATETIME_KEY] instanceof DateTime)) {


### PR DESCRIPTION
Declaration of Myli\DatadogLogger\DataDogFormatter::format(array $record) must be 
compatible with Monolog\Formatter\JsonFormatter::format(array $record): string.

for Monolog version 2